### PR TITLE
Add TIGRESS support.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+MakeBGOHistograms

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MakeBGOHistograms
 This project is designed to sort and histogram 137Cs source data from the
-GRIFFIN HPGe array at TRIUMF-ISAC for the purpose of voltage matching the BGO
+GRIFFIN or TIGRESS HPGe arrays at TRIUMF-ISAC for the purpose of voltage matching the BGO
 suppressor shields.
 
 ## Table of Contents
@@ -30,7 +30,7 @@ The general form of input is:
 ##### Parameters
 ```
 analysis_tree     The unpacked analysis tree containing 137Cs source data
-calibration_file  GRIFFIN calibration file
+calibration_file  GRIFFIN/TIGRESS calibration file
 out_file_name     optional, Name of output file
                   default: outFile.root
 ```


### PR DESCRIPTION
This adds support for generating BGO histograms for TIGRESS (since the BGOs are handled differently in the TTigress class vs. TGriffin).  The changes were mostly by S. Gillespie, with some minor cleanups by me.  Seems to work as of the latest TIGRESS run.  I think it should still work the same for GRIFFIN as before.

I'll look through the rest of the gain matching codes and make PRs if there's anything we've updated on the TIGRESS side.